### PR TITLE
breaking: seprating sections with `\n\n` & drop `SSHConfig.find()`

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,10 @@
+3.0.0 / 2019-12-12
+==================
+
+ * Breaking: prefer to separate sections with `\n\n`
+ * Breaking: drop `SSHConfig.find()`, please use `SSHConfig.prototype.find()` instead
+
+
 2.0.0 / 2019-10-08
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssh-config",
   "description": "SSH config parser and stringifier",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "author": "Chen Yangjian (https://www.cyj.me)",
   "repository": {
     "type": "git",

--- a/test/test.ssh-config.js
+++ b/test/test.ssh-config.js
@@ -247,9 +247,10 @@ describe('SSHConfig', function() {
       HostName: 'microsoft.com'
     })
 
-    assert(config.toString() === heredoc(function() {/*
+    assert.equal(config.toString(), heredoc(function() {/*
       Host test
         HostName google.com
+
       Host test2
         HostName microsoft.com
     */}))
@@ -263,23 +264,23 @@ describe('SSHConfig', function() {
       HostName: 'example.com'
     })
 
-    assert(config.toString() === heredoc(function() {/*
+    assert.equal(config.toString(), heredoc(function() {/*
       IdentityFile ~/.ssh/id_rsa
+
       Host test2
         HostName example.com
     */}))
   })
 
-  it('SSHConfig.find should be deprecated', function() {
-    const config = SSHConfig.parse(heredoc(function() {/*
-      Host foo
+  it('.append to empty section config', function() {
+    const config = SSHConfig.parse('Host test')
+    config.append({
+      HostName: 'example.com'
+    })
+
+    assert.equal(config.toString(), heredoc(function() {/*
+      Host test
         HostName example.com
     */}))
-    const result = SSHConfig.find(config, { Host: 'foo' })
-    assert(Array.isArray(result))
-    const section = result[0]
-    assert(section != null)
-    assert.equal(section.param, 'Host')
-    assert.equal(section.value, 'foo')
   })
 })


### PR DESCRIPTION
cc @roblourens 
closes #23 (again)