### PR TITLE
Return a list for all properties that can have multiple values

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,12 @@ const COMMENT = 2
 function compare(line, opts) {
   return opts.hasOwnProperty(line.param) && opts[line.param] === line.value
 }
+const MULTIPLE_VALUE_PROPS = [
+  'IdentityFile',
+  'LocalForward',
+  'RemoteForward',
+  'DynamicForward'
+];
 
 class SSHConfig extends Array {
   /**
@@ -22,7 +28,7 @@ class SSHConfig extends Array {
   compute(host) {
     const obj = {}
     const setProperty = (name, value) => {
-      if (name === 'IdentityFile') {
+      if (MULTIPLE_VALUE_PROPS.includes(name)) {
         const list = obj[name] || (obj[name] = [])
         list.push(value)
       }

--- a/index.js
+++ b/index.js
@@ -12,11 +12,13 @@ const COMMENT = 2
 function compare(line, opts) {
   return opts.hasOwnProperty(line.param) && opts[line.param] === line.value
 }
+
 const MULTIPLE_VALUE_PROPS = [
   'IdentityFile',
   'LocalForward',
   'RemoteForward',
-  'DynamicForward'
+  'DynamicForward',
+  'CertificateFile'
 ];
 
 class SSHConfig extends Array {

--- a/test/test.ssh-config.js
+++ b/test/test.ssh-config.js
@@ -296,4 +296,27 @@ describe('SSHConfig', function() {
         HostName example.com
     */}))
   })
+
+  it('.compute with properties with multiple values', function() {
+    const config = SSHConfig.parse(heredoc(function() {/*
+      Host myHost
+        HostName example.com
+        LocalForward 1234 localhost:1234
+        CertificateFile /foo/bar
+        LocalForward 9876 localhost:9876
+        CertificateFile /foo/bar2
+        RemoteForward 8888 localhost:8888
+
+      Host *
+        CertificateFile /foo/bar3
+    */}))
+
+    assert.deepEqual(config.compute('myHost'), {
+      Host: 'myHost',
+      HostName: 'example.com',
+      LocalForward: ['1234 localhost:1234', '9876 localhost:9876'],
+      RemoteForward: ['8888 localhost:8888'],
+      CertificateFile: ['/foo/bar', '/foo/bar2', '/foo/bar3']
+    })
+  })
 })


### PR DESCRIPTION
Browsing the ssh_config man page, I think there are a couple others that can have multiple values, but I don't have an easy way to test them right now, and I think this would be fine until someone complains?

Fix #30