### PR TITLE
Escape some special characters before matching by regex

### DIFF
--- a/src/glob.js
+++ b/src/glob.js
@@ -1,9 +1,16 @@
 'use strict'
 
+function escapeChars(str, chars) {
+  for (let char of chars) {
+    str = str.replace(new RegExp('\\' + char, 'g'), '\\' + char)
+  }
+
+  return str
+}
+
 function match(pattern, str) {
+  pattern = escapeChars(pattern, '\\()[]{}.+^$|');
   pattern = pattern
-    .replace(/\./g, '\\.')
-    .replace(/\+/g, '\\+')
     .replace(/\*/g, '.*')
     .replace(/\?/g, '.?')
 

--- a/test/test.glob.js
+++ b/test/test.glob.js
@@ -42,4 +42,12 @@ describe('glob', function() {
     assert(glob('*/*', 'host1/host2'))
     assert(glob('*+*', 'host1+host2'))
   })
+
+  it('glob special chars', function() {
+    assert(glob('(foo', '(foo'))
+    assert(!glob('(foo)', 'foo'))
+    assert(glob('[foo]', '[foo]'))
+    assert(glob('{foo', '{foo'))
+    assert(glob('^foo|ba\\r$', '^foo|ba\\r$'))
+  })
 })


### PR DESCRIPTION
These characters are all actually accepted
by OpenSSH in host names and parsed correctly from
the config.
Fix #34