### PR TITLE
Quote IdentityFile property when it contains a space

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const RE_SPACE = /\s/
 const RE_LINE_BREAK = /\r|\n/
 const RE_SECTION_DIRECTIVE = /^(Host|Match)$/i
 const RE_MULTI_VALUE_DIRECTIVE = /^(GlobalKnownHostsFile|Host|IPQoS|SendEnv|UserKnownHostsFile)$/i
-const RE_QUOTE_DIRECTIVE = /^(?:CertificateFile|IdentifyFile|User)$/i
+const RE_QUOTE_DIRECTIVE = /^(?:CertificateFile|IdentityFile|User)$/i
 
 const DIRECTIVE = 1
 const COMMENT = 2

--- a/test/test.stringify.js
+++ b/test/test.stringify.js
@@ -119,4 +119,17 @@ describe('stringify', function() {
         LocalForward 3000 127.0.0.1:3000
     */}))
   })
+
+  // #43
+  it('.stringify IdentityFile with spaces', function() {
+    const config = new SSHConfig().append({
+      Host: 'foo',
+      IdentityFile: 'C:\\Users\\John Doe\\.ssh\\id_rsa'
+    })
+
+    assert.equal(stringify(config), heredoc(function() {/*
+      Host foo
+        IdentityFile "C:\Users\John Doe\.ssh\id_rsa"
+    */}))
+  })
 })


### PR DESCRIPTION
Fix typo in prop name to check for quote

Reported in microsoft/vscode-remote-release#4999