### PR TITLE
test: switching to github actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,23 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install, build, and test
+      run: |
+        npm install
+        npm run build --if-present
+        npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ node_js:
   - "node"
   - "lts/*"
   - "10"
-  - "8"
-  - "6"
 
 after_success:
   - npm install coveralls

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "coveralls": "nyc mocha --exit && nyc report --reporter=text-lcov | coveralls"
   },
   "engine": {
-    "node": ">= 6.0.0"
+    "node": ">= 10.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
also removed node 6.x and 8.x in travis-ci, which has been broken for a while.