### PR TITLE
Improve support for obscure ssh_config(5) rules

### DIFF
--- a/src/ssh-config.ts
+++ b/src/ssh-config.ts
@@ -509,7 +509,11 @@ export function parse(text: string): SSHConfig {
     }
     else if (node.type === LineType.DIRECTIVE && !node.param) {
       // blank lines at file end
-      config[config.length - 1].after += node.before
+      if (config.length === 0) {
+        configWas[configWas.length - 1].after += node.before
+      } else {
+        config[config.length - 1].after += node.before
+      }
     }
     else {
       config.push(node)

--- a/src/ssh-config.ts
+++ b/src/ssh-config.ts
@@ -477,11 +477,31 @@ export function parse(text: string): SSHConfig {
     }
     if (!result.quoted) delete result.quoted
     if (/^Match$/i.test(param)) {
-      const criteria = {}
-      for (let i = 0; i < result.value.length; i += 2) {
+      const criteria: Match['criteria'] = {}
+
+      if (typeof result.value === "string") {
+        result.value = [result.value]
+      }
+
+      let i = 0
+      while (i < result.value.length) {
         const keyword = result.value[i]
-        const value = result.value[i + 1]
-        criteria[keyword] = value
+
+        switch (keyword.toLowerCase()) {
+          case "all":
+          case "canonical":
+          case "final":
+            criteria[keyword] = []
+            i += 1
+            break
+          default:
+            if (i + 1 >= result.value.length) {
+              throw new Error(`Missing value for match criteria ${keyword}`)
+            }
+            criteria[keyword] = result.value[i + 1]
+            i += 2
+            break
+        }
       }
       (result as Match).criteria = criteria
     }

--- a/src/ssh-config.ts
+++ b/src/ssh-config.ts
@@ -130,6 +130,10 @@ class SSHConfig extends Array<Line> {
       }
     }
 
+    if (opts.User !== undefined) {
+      setProperty("User", opts.User)
+    }
+
     for (const line of this) {
       if (line.type !== LineType.DIRECTIVE) continue
       if (line.param === 'Host' && glob(line.value, params.Host)) {

--- a/test/unit/parse.test.ts
+++ b/test/unit/parse.test.ts
@@ -263,10 +263,24 @@ describe('parse', function() {
     })
   })
 
+  it('.parse standalone match criteria', function() {
+    const config = parse(`
+      Match all canonical final
+    `)
+    const match = config.find(line => line.type === DIRECTIVE && line.param === 'Match')
+    assert.ok(match)
+    assert.ok('criteria' in match)
+    assert.deepEqual(match.criteria, {
+      all: [],
+      canonical: [],
+      final: [],
+    })
+  })
+
   // https://github.com/cyjake/ssh-config/issues/58
   it('.parse match criteria', function() {
     const config = parse(`
-      Match exec "/Users/me/onsubnet --not 192.168.1." host docker
+      Match exec "/Users/me/onsubnet --not 192.168.1." final host docker
         ProxyJump exthost
         Hostname 192.168.1.10
         User user1
@@ -281,6 +295,7 @@ describe('parse', function() {
     assert.deepEqual(match.criteria, {
       exec: '/Users/me/onsubnet --not 192.168.1.',
       host: 'docker',
+      final: [],
     })
   })
 })

--- a/test/unit/ssh-config.test.ts
+++ b/test/unit/ssh-config.test.ts
@@ -131,6 +131,16 @@ describe('SSHConfig', function() {
     assert.equal(result.Match, undefined)
   })
 
+  it('.compute by explicit user', async function() {
+    const config = SSHConfig.parse(`
+      User wrong
+    `)
+    const result = config.compute({ Host: 'tahoe1', User: 'bar' })
+    assert.ok(result)
+    assert.equal(result.User, 'bar')
+  })
+
+
   it('.find with nothing shall yield error', async function() {
     const config = SSHConfig.parse(readFile('fixture/config'))
     assert.throws(function() { config.find({}) })

--- a/test/unit/ssh-config.test.ts
+++ b/test/unit/ssh-config.test.ts
@@ -140,6 +140,39 @@ describe('SSHConfig', function() {
     assert.equal(result.User, 'bar')
   })
 
+  it('.compute by Match host uses HostName', async function() {
+    const config = SSHConfig.parse(`
+      Host tahoe
+        HostName tahoe.com
+
+      # Host does not use HostName until the second pass
+      Host *.com
+        ProxyJump wrong.proxy.com
+
+      Match host *.com
+        ProxyJump proxy.com
+    `)
+    const result = config.compute({ Host: 'tahoe' })
+    assert.ok(result)
+    assert.equal(result.HostName, 'tahoe.com')
+    assert.equal(result.ProxyJump, 'proxy.com')
+  })
+
+  it('.compute with Match final does second pass with HostName', async function() {
+    const config = SSHConfig.parse(`
+      Match final
+
+      Host tahoe
+        HostName tahoe.com
+
+      Host *.com
+        ProxyJump proxy.com
+    `)
+    const result = config.compute({ Host: 'tahoe' })
+    assert.ok(result)
+    assert.equal(result.HostName, 'tahoe.com')
+    assert.equal(result.ProxyJump, 'proxy.com')
+  })
 
   it('.find with nothing shall yield error', async function() {
     const config = SSHConfig.parse(readFile('fixture/config'))

--- a/test/unit/stringify.test.ts
+++ b/test/unit/stringify.test.ts
@@ -171,11 +171,11 @@ describe('stringify', function() {
 
   it('.stringify Match with criteria', function() {
     const config = parse(`
-      Match host foo exec "return 0"
+      Match host foo final exec "return 0"
         HostName localhost
     `)
     assert.equal(stringify(config), `
-      Match host foo exec "return 0"
+      Match host foo final exec "return 0"
         HostName localhost
     `)
   })


### PR DESCRIPTION
There are some obscure interactions in the SSH config parsing rules. This PR extends support for some of these, which addresses the bug that prompted https://github.com/jeanp413/open-remote-ssh/pull/103.

The `canonical` criteria is not properly supported in this series because I don't use it, so don't really have a sense for what it should be doing. It shouldn't be too hard to extend support for it too though, now that the second pass is possible.